### PR TITLE
Fixing regression while converting key/value pair into Zipkin binary annotation

### DIFF
--- a/htrace-zipkin/src/main/java/org/apache/htrace/zipkin/HTraceToZipkinConverter.java
+++ b/htrace-zipkin/src/main/java/org/apache/htrace/zipkin/HTraceToZipkinConverter.java
@@ -154,7 +154,7 @@ public class HTraceToZipkinConverter {
     List<BinaryAnnotation> l = new ArrayList<BinaryAnnotation>();
     for (Map.Entry<String, String> e : span.getKVAnnotations().entrySet()) {
       BinaryAnnotation binaryAnn = new BinaryAnnotation();
-      binaryAnn.setAnnotation_type(AnnotationType.BYTES);
+      binaryAnn.setAnnotation_type(AnnotationType.STRING);
       binaryAnn.setKey(e.getKey());
       try {
         binaryAnn.setValue(e.getValue().getBytes("UTF-8"));


### PR DESCRIPTION
Hey guys!

The recent changes into the HTrace's key/value handling implementation (from byte[] to String) caused a regression in Zipkin integration (as annotation type should be STRING in this case instead of BYTES). 

Here is the screenshot from `zipkin-web` **before the fix** while storing `Sample Key -> Sample Value` key pair:

![image](https://cloud.githubusercontent.com/assets/509855/11515812/b4e76130-9834-11e5-8697-b1e121f17b70.png)

Here is the same key/value **after the fix**:

![image](https://cloud.githubusercontent.com/assets/509855/11515830/c9f40e66-9834-11e5-9591-015326dbceb1.png)

I could provide sample project as well but issue is very easily reproducible.
Thanks!

Best Regards,
    Andriy Redko
