### PR TITLE
Fixed 'null' scope usage in case no sampling is being performed

### DIFF
--- a/htrace-core4/src/main/java/org/apache/htrace/core/Tracer.java
+++ b/htrace-core4/src/main/java/org/apache/htrace/core/Tracer.java
@@ -381,7 +381,7 @@ public class Tracer implements Closeable {
     }
     if (!sample()) {
       context.pushScope();
-      return nullScope;
+      return new NullScope(this);
     }
     return newScopeImpl(context, description);
   }
@@ -407,7 +407,7 @@ public class Tracer implements Closeable {
     }
     if (!sample()) {
       context.pushScope();
-      return nullScope;
+      return new NullScope(this);
     }
     return newScopeImpl(context, description);
   }
@@ -418,7 +418,7 @@ public class Tracer implements Closeable {
   public TraceScope newNullScope() {
     ThreadContext context = threadContext.get();
     context.pushScope();
-    return nullScope;
+    return new NullScope(this);
   }
 
   /**


### PR DESCRIPTION
Hey guys!

Yet another suggested fix related to the 'null' scope singleton usage. When no sampling is being done for current execution flow, the tracer always return the **singleton** instance of 'null' scope. It causes many issues in case when new scope is asked to be created and then attached or/and detached by multiple concurrent executions (threads): one thread successfully use newScope / detach sequence while another one immediately fails with the exception that scope is already detached. 

Suggested fix is to use new NullScope instance every time instead of singleton one. The simple project to reproduce the issue could be attached as well.

Thanks!

Best Regards,
    Andriy Redko
