### PR TITLE
Changed binary annotations type from binary to string

### DIFF
--- a/htrace-zipkin/pom.xml
+++ b/htrace-zipkin/pom.xml
@@ -149,6 +149,12 @@ language governing permissions and limitations under the License. -->
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin-collector-scribe</artifactId>
+      <version>1.19.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/htrace-zipkin/src/main/java/org/apache/htrace/zipkin/HTraceToZipkinConverter.java
+++ b/htrace-zipkin/src/main/java/org/apache/htrace/zipkin/HTraceToZipkinConverter.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.htrace.core.TimelineAnnotation;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -153,13 +154,9 @@ public class HTraceToZipkinConverter {
     List<BinaryAnnotation> l = new ArrayList<BinaryAnnotation>();
     for (Map.Entry<String, String> e : span.getKVAnnotations().entrySet()) {
       BinaryAnnotation binaryAnn = new BinaryAnnotation();
-      binaryAnn.setAnnotation_type(AnnotationType.BYTES);
+      binaryAnn.setAnnotation_type(AnnotationType.STRING);
       binaryAnn.setKey(e.getKey());
-      try {
-        binaryAnn.setValue(e.getValue().getBytes("UTF-8"));
-      } catch (UnsupportedEncodingException ex) {
-        LOG.error("Error encoding string as UTF-8", ex);
-      }
+      binaryAnn.setValue(e.getValue().getBytes(StandardCharsets.UTF_8));
       binaryAnn.setHost(ep);
       l.add(binaryAnn);
     }

--- a/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ITZipkinReceiverTest.java
+++ b/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ITZipkinReceiverTest.java
@@ -52,7 +52,7 @@ import kafka.zk.EmbeddedZookeeper;
 import scala.collection.JavaConversions;
 import scala.collection.mutable.Buffer;
 
-public class ITZipkinReceiver {
+public class ITZipkinReceiverTest {
 
   @Test
   public void testKafkaTransport() throws Exception {

--- a/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSender.java
+++ b/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSender.java
@@ -69,7 +69,7 @@ public class ScribeThriftSender {
     }
 
     @Test
-    public void sendsSpans() throws Exception {
+    public void testBinaryAnnotationsEncoding() throws Exception {
         Tracer t = newTracer(sender);
         TraceScope s = t.newScope("root");
         String originalValue = "bar";

--- a/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSender.java
+++ b/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSender.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.htrace.zipkin;
+
+import org.apache.htrace.Transport;
+import org.apache.htrace.core.*;
+import org.apache.htrace.impl.ScribeTransport;
+import org.apache.htrace.impl.ZipkinSpanReceiver;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.scribe.ScribeCollector;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.QueryRequest;
+
+import java.util.List;
+
+public class ScribeThriftSender {
+
+    InMemoryStorage storage = new InMemoryStorage();
+    ScribeCollector collector;
+
+    @Before
+    public void start() {
+        collector = ScribeCollector.builder()
+                .metrics(CollectorMetrics.NOOP_METRICS)
+                .storage(storage).build();
+        collector.start();
+    }
+
+    @After
+    public void close() {
+        collector.close();
+    }
+
+    ScribeTransport sender = new ScribeTransport();
+
+    private Tracer newTracer(final Transport transport) {
+        TracerPool pool = new TracerPool("newTracer");
+        pool.addReceiver(new ZipkinSpanReceiver(HTraceConfiguration.EMPTY) {
+            @Override
+            protected Transport createTransport(HTraceConfiguration conf) {
+                return transport;
+            }
+        });
+        return new Tracer.Builder("ZipkinTracer").
+                tracerPool(pool).
+                conf(HTraceConfiguration.fromKeyValuePairs(
+                        "sampler.classes", AlwaysSampler.class.getName()
+                )).
+                build();
+    }
+
+    @Test
+    public void sendsSpans() throws Exception {
+        Tracer t = newTracer(sender);
+        TraceScope s = t.newScope("root");
+        String originalValue = "bar";
+        s.addKVAnnotation("foo", originalValue);
+        s.close();
+        List<List<zipkin.Span>> spans = storage.spanStore().getTraces(QueryRequest.builder().build());
+        Assert.assertEquals(new String(spans.listIterator().next().get(0).binaryAnnotations.get(0).value), originalValue);
+        t.close();
+    }
+}

--- a/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSenderTest.java
+++ b/htrace-zipkin/src/test/java/org/apache/htrace/zipkin/ScribeThriftSenderTest.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import zipkin.BinaryAnnotation;
 import zipkin.collector.CollectorMetrics;
 import zipkin.collector.scribe.ScribeCollector;
 import zipkin.storage.InMemoryStorage;
@@ -32,7 +33,7 @@ import zipkin.storage.QueryRequest;
 
 import java.util.List;
 
-public class ScribeThriftSender {
+public class ScribeThriftSenderTest {
 
     InMemoryStorage storage = new InMemoryStorage();
     ScribeCollector collector;
@@ -69,14 +70,14 @@ public class ScribeThriftSender {
     }
 
     @Test
-    public void testBinaryAnnotationsEncoding() throws Exception {
+    public void testBinaryAnnotationsType() throws Exception {
         Tracer t = newTracer(sender);
         TraceScope s = t.newScope("root");
         String originalValue = "bar";
         s.addKVAnnotation("foo", originalValue);
         s.close();
-        List<List<zipkin.Span>> spans = storage.spanStore().getTraces(QueryRequest.builder().build());
-        Assert.assertEquals(new String(spans.listIterator().next().get(0).binaryAnnotations.get(0).value), originalValue);
         t.close();
+        List<List<zipkin.Span>> spans = storage.spanStore().getTraces(QueryRequest.builder().build());
+        Assert.assertEquals(spans.listIterator().next().get(0).binaryAnnotations.get(0).type, BinaryAnnotation.Type.STRING);
     }
 }


### PR DESCRIPTION
The thrift Annotation Type doesn't conform to the actual type it encodes. Notice the  `TraceScope.addKVAnnotation` function signature:
 ```java
public void addKVAnnotation(String key, String value)
```

Using `StandardCharsets` doesn't throw the `UnsupportedEncodingException`
